### PR TITLE
prefecture_idのアンダーバーの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |zip_code|string|null: false|
-|prefecture＿id|integer|null: false|
+|prefecture_id|integer|null: false|
 |city|string|null: false|
 |number|string|null: false|
 |building|string||


### PR DESCRIPTION
# what
prefecture_idのアンダーバーが全角だったのを半角に修正
#why
_が全角になっていたため