### PR TITLE
パンくず機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,4 @@ gem 'omniauth-google-oauth2'
 gem 'devise'
 gem 'dotenv-rails'
 gem 'ancestry'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -399,6 +401,7 @@ DEPENDENCIES
   factory_bot_rails
   fog-aws
   font-awesome-rails
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/views/mypages/_bread-crumbs.html.haml
+++ b/app/views/mypages/_bread-crumbs.html.haml
@@ -1,8 +1,4 @@
 %nav.bread-crumbs
   %ul
-    %li{itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb"}
-      -# = link_to root_path, itemprop: "url" do
-        %span{itemprop: "title"} メルカリ
-      %i.icon-arrow-right
-    %li{itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb"}
-      %span{itemprop: "title"} マイページ
+    %li
+    = breadcrumbs pretext: "",separator: " &nbsp;&nbsp;&#12297;&nbsp; ", class: "breadcrumbs-list"

--- a/app/views/mypages/_bread-crumbs.html.haml
+++ b/app/views/mypages/_bread-crumbs.html.haml
@@ -1,4 +1,7 @@
 %nav.bread-crumbs
   %ul
     %li
+    -# 下記を記述した箇所にパンくずリストが表示される。
+    -# pretext ← パンくずリストの先頭に挿入する文章を記述。いらない場合は設定しなくて大丈夫です。
+    -# separator ← パンくずの区切り文字を指定。
     = breadcrumbs pretext: "",separator: " &nbsp;&nbsp;&#12297;&nbsp; ", class: "breadcrumbs-list"

--- a/app/views/mypages/credit.html.haml
+++ b/app/views/mypages/credit.html.haml
@@ -1,4 +1,5 @@
 = render "header"
+-# config/breadcrumbs.rbに定義したcreditを呼び出し
 - breadcrumb :credit
 = render "bread-crumbs"
 %main.l-container.clearfix

--- a/app/views/mypages/credit.html.haml
+++ b/app/views/mypages/credit.html.haml
@@ -1,4 +1,5 @@
 = render "header"
+- breadcrumb :credit
 = render "bread-crumbs"
 %main.l-container.clearfix
   .l-content

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -1,4 +1,5 @@
 = render "header"
+-# config/breadcrumbs.rbに定義したidentificationを呼び出し
 - breadcrumb :identification
 = render "bread-crumbs"
 %main.l-container.clearfix

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -1,4 +1,5 @@
 = render "header"
+- breadcrumb :identification
 = render "bread-crumbs"
 %main.l-container.clearfix
   .l-content

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -1,4 +1,5 @@
 = render "header"
+-# config/breadcrumbs.rbに定義したmypagesを呼び出し
 - breadcrumb :mypages
 = render "bread-crumbs"
 %main.l-container.clearfix

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -1,4 +1,5 @@
 = render "header"
+- breadcrumb :mypages
 = render "bread-crumbs"
 %main.l-container.clearfix
   .l-content

--- a/app/views/mypages/logout.html.haml
+++ b/app/views/mypages/logout.html.haml
@@ -1,4 +1,5 @@
 = render "header"
+- breadcrumb :logout
 = render "bread-crumbs"
 %main.l-container.clearfix
   .l-content

--- a/app/views/mypages/logout.html.haml
+++ b/app/views/mypages/logout.html.haml
@@ -1,4 +1,5 @@
 = render "header"
+-# config/breadcrumbs.rbに定義したlogoutを呼び出し
 - breadcrumb :logout
 = render "bread-crumbs"
 %main.l-container.clearfix

--- a/app/views/mypages/profile.html.haml
+++ b/app/views/mypages/profile.html.haml
@@ -1,4 +1,5 @@
 = render "header"
+- breadcrumb :profile
 = render "bread-crumbs"
 %main.l-container.clearfix
   .l-content

--- a/app/views/mypages/profile.html.haml
+++ b/app/views/mypages/profile.html.haml
@@ -1,4 +1,5 @@
 = render "header"
+-# config/breadcrumbs.rbに定義したprofileを呼び出し
 - breadcrumb :profile
 = render "bread-crumbs"
 %main.l-container.clearfix

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,31 +2,36 @@ crumb :root do
   link "メルカリ", root_path
 end
 
+# Gemのgretelが何をしているかを記載しておきます。
+# ・ :mypages ← 設定ファイルを呼び出します。
+# ・ "マイページ" ← パンくずリストに表示される名称です。
+# ・ mypage_path ← 呼び出し元のパスを指定します。（rails routesでパスを確認しましょう）
 # マイページ
 crumb :mypages do
   link "マイページ", mypages_path
 end
 
-
+# config/breadcrumb.rbのcrumbとendの間に
+# parentを設定することで親を設定することができます。
 # プロフィール
 crumb :profile do
   link "プロフィール", profile_mypages_path
   parent :mypages
 end
 
-# プロフィール
+# 支払い方法（クレジットカード）
 crumb :credit do
   link "支払い方法", credit_mypages_path
   parent :mypages
 end
 
-# プロフィール
+# 本人情報
 crumb :identification do
   link "本人情報", identification_mypages_path
   parent :mypages
 end
 
-# プロフィール
+# ログアウト
 crumb :logout do
   link "ログアウト", logout_mypages_path
   parent :mypages

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,58 @@
+crumb :root do
+  link "メルカリ", root_path
+end
+
+# マイページ
+crumb :mypages do
+  link "マイページ", mypages_path
+end
+
+
+# プロフィール
+crumb :profile do
+  link "プロフィール", profile_mypages_path
+  parent :mypages
+end
+
+# プロフィール
+crumb :credit do
+  link "支払い方法", credit_mypages_path
+  parent :mypages
+end
+
+# プロフィール
+crumb :identification do
+  link "本人情報", identification_mypages_path
+  parent :mypages
+end
+
+# プロフィール
+crumb :logout do
+  link "ログアウト", logout_mypages_path
+  parent :mypages
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
# What
gemのgretelを用いて、パンくず機能を実装。
現在は、マイページの部分のみ実装。
CSSは後ほど修正する可能性有り。

**チームメンバー用にコード内にコメントを記載している箇所が多々あります。
ご容赦ください。**

gretelの公式
https://www.rubydoc.info/gems/gretel

# Why
ユーザーの観点から、自身が今どこにいるのかがわかりやすいこと
トップページなどに戻るときにリンクがあるので少し楽。（普通に戻るボタン使う人もいるとは思うけど）
作成者側としては、ページの遷移の再確認をすることができる。