### PR TITLE
②商品一覧のsold outの表記を消す。

### DIFF
--- a/app/views/homes/index.html.haml
+++ b/app/views/homes/index.html.haml
@@ -72,12 +72,12 @@
                 .items-box-price
                   ¥#{item.price}
 
-                -if item.shopping_status == 1
-                  .items-box_photo__sold
-                    .items-box_photo__sold__inner
-                      SOLD
-                  .items-box-name
-                    #{item.name}
+                -# -if item.shopping_status == 1
+                -#   .items-box_photo__sold
+                -#     .items-box_photo__sold__inner
+                -#       SOLD
+                -#   .items-box-name
+                -#     #{item.name}
                       
 
 


### PR DESCRIPTION
WHAT
購入後「Sold out」のラベルがでるが、商品一覧と商品詳細ページで不一致が起きているので修正。

WHY
購入後「Sold out」のラベルがでるが、商品一覧と商品詳細ページで不一致が起きているので修正。