### PR TITLE
販売価格値のリアルタイム変動

### DIFF
--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -1,0 +1,21 @@
+$(function(){
+  $('#price_calc').on('input', function(){   //リアルタイムで表示したいのでinputを使う｡入力の度にイベントが発火するようになる｡
+    var data = $('#price_calc').val(); // val()でフォームのvalueを取得(数値)
+    var profit = Math.round(data * 0.9)  // 手数料計算を行う｡dataにかけているのが0.9なのは単に引きたい手数料が10%のため｡
+    var fee = (data - profit) // 入力した数値から計算結果(profit)を引く｡それが手数料となる｡
+    $('.l-right1').html(fee) //  手数料の表示｡html()は追加ではなく､上書き｡入力値が変わる度に表示も変わるようにする｡
+    $('.l-right1').prepend('¥') // 手数料の前に¥マークを付けたいので
+    $('.l-right2').html(profit)
+    $('.l-right2').prepend('¥')
+  })
+// 編集時、販売利益と手数料をページ読み込みと同時に表示させる記述
+  $('#price_calc').ready(function(){   //リアルタイムで表示したいのでinputを使う｡入力の度にイベントが発火するようになる｡
+    var data = $('#price_calc').val(); // val()でフォームのvalueを取得(数値)
+    var profit = Math.round(data * 0.9)  // 手数料計算を行う｡dataにかけているのが0.9なのは単に引きたい手数料が10%のため｡
+    var fee = (data - profit) // 入力した数値から計算結果(profit)を引く｡それが手数料となる｡
+    $('.l-right1').html(fee) //  手数料の表示｡html()は追加ではなく､上書き｡入力値が変わる度に表示も変わるようにする｡
+    $('.l-right1').prepend('¥') // 手数料の前に¥マークを付けたいので
+    $('.l-right2').html(profit)
+    $('.l-right2').prepend('¥')
+  })
+})

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -283,10 +283,14 @@ nav ul {
     color: #333;
 }*/
 
-.l-right {
+.l-right1 {
     float: right;
 }
 
+.l-right2 {
+    float: right;
+    font-size:24px;
+}
 
 .pc-header-user-nav {
     font-size: 0;

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -96,14 +96,14 @@
                         価格
                         %span.form-require 必須
                       .l-right.sell-price-input
-                        = f.text_field :price, placeholder: "例) 300",class:"input-default"
+                        = f.text_field :price, placeholder: "例) 300",class:"input-default", id:"price_calc"
                   %li.clearfix
                     .l-left
                       販売手数料 (10%)
-                    .l-right -
+                    .l-right1 -
                   %li.clearfix.bold
                     .l-left 販売利益
-                    .l-right -
+                    .l-right2 -
             .modal{role: "dialog", tabindex: "-1"}
               .modal-inner
             .sell-content.sell-btn-box

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -89,14 +89,14 @@
                         価格
                         %span.form-require 必須
                       .l-right.sell-price-input
-                        = f.text_field :price, placeholder: "例) 300",class:"input-default"
+                        = f.text_field :price, placeholder: "例) 300",class:"input-default", id:"price_calc"
                   %li.clearfix
                     .l-left
                       販売手数料 (10%)
-                    .l-right -
+                    .l-right1 -
                   %li.clearfix.bold
                     .l-left 販売利益
-                    .l-right -
+                    .l-right2 -
             .modal{role: "dialog", tabindex: "-1"}
               .modal-inner
             .sell-content.sell-btn-box


### PR DESCRIPTION
#what
新規投稿と編集時に、販売価格の入力値によって手数料、販売履歴をリアルタイムで変化させるjsの記述を追加

#why
機能として不十分だった為